### PR TITLE
Concat whole collections together

### DIFF
--- a/src/__tests__/concat.ts
+++ b/src/__tests__/concat.ts
@@ -1,0 +1,54 @@
+import test from 'ava';
+import * as RD from '@cala/remote-data';
+import Collection from '../index';
+import { Item, items } from './fixtures';
+
+const moreItems = [{ id: 'c', foo: 'test' }, { id: 'd', foo: 'test' }];
+
+test('with non-overlapping two collections', t => {
+  const other = new Collection<Item>().withList('id', moreItems);
+  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  t.deepEqual(
+    col.knownIds,
+    RD.success<string[], string[]>(['a', 'b', 'c', 'd']),
+    'appends the additional ids'
+  );
+  t.deepEqual(
+    col.entities,
+    {
+      a: RD.success<string[], Item>(items[0]),
+      b: RD.success<string[], Item>(items[1]),
+      c: RD.success<string[], Item>(moreItems[0]),
+      d: RD.success<string[], Item>(moreItems[1])
+    },
+    'appends the additional items'
+  );
+});
+
+test('with the same collection twice', t => {
+  const other = new Collection<Item>().withList('id', items);
+  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']), 'does not update ids');
+  t.deepEqual(
+    col.entities,
+    {
+      a: RD.success<string[], Item>(items[0]),
+      b: RD.success<string[], Item>(items[1])
+    },
+    'does not update entities'
+  );
+});
+
+test('with an empty collection', t => {
+  const other = new Collection<Item>();
+  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']), 'does not update ids');
+  t.deepEqual(
+    col.entities,
+    {
+      a: RD.success<string[], Item>(items[0]),
+      b: RD.success<string[], Item>(items[1])
+    },
+    'does not update entities'
+  );
+});

--- a/src/__tests__/with-resource.ts
+++ b/src/__tests__/with-resource.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import RemoteCollection from '../index';
+import Collection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withResource', t => {
-  const col = new RemoteCollection<Item>().withResource('a', items[0]);
+  const col = new Collection<Item>().withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,
@@ -14,7 +14,7 @@ test('with no items loaded, #withResource', t => {
 });
 
 test('with items loaded, #withResource on an existing ID', t => {
-  const col = new RemoteCollection<Item>()
+  const col = new Collection<Item>()
     .withList('id', items)
     .withResource('a', { id: 'a', foo: 'quux' });
   t.deepEqual(
@@ -33,7 +33,7 @@ test('with items loaded, #withResource on an existing ID', t => {
 });
 
 test('with items loaded, #withResource on an unknown ID', t => {
-  const col = new RemoteCollection<Item>()
+  const col = new Collection<Item>()
     .withList('id', items)
     .withResource('z', { id: 'z', foo: 'zed' });
   t.deepEqual(
@@ -53,7 +53,7 @@ test('with items loaded, #withResource on an unknown ID', t => {
 });
 
 test('with item loading failure, #withResource', t => {
-  const col = new RemoteCollection<Item>().withListFailure('Failed').withResource('a', items[0]);
+  const col = new Collection<Item>().withListFailure('Failed').withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,

--- a/src/__tests__/with-resource.ts
+++ b/src/__tests__/with-resource.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withResource', t => {
-  const col = new Collection<Item>().withResource('a', items[0]);
+  const col = new RemoteCollection<Item>().withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,
@@ -14,7 +14,7 @@ test('with no items loaded, #withResource', t => {
 });
 
 test('with items loaded, #withResource on an existing ID', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withList('id', items)
     .withResource('a', { id: 'a', foo: 'quux' });
   t.deepEqual(
@@ -33,7 +33,7 @@ test('with items loaded, #withResource on an existing ID', t => {
 });
 
 test('with items loaded, #withResource on an unknown ID', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withList('id', items)
     .withResource('z', { id: 'z', foo: 'zed' });
   t.deepEqual(
@@ -53,7 +53,7 @@ test('with items loaded, #withResource on an unknown ID', t => {
 });
 
 test('with item loading failure, #withResource', t => {
-  const col = new Collection<Item>().withListFailure('Failed').withResource('a', items[0]);
+  const col = new RemoteCollection<Item>().withListFailure('Failed').withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public withList(idProp: string, list: Resource[]): Collection<Resource> {
+  public withList(idProp: keyof Resource, list: Resource[]): Collection<Resource> {
     const col = new Collection(this);
     const idsAndSuccesses: [string, Remote<Resource>][] = list.map(
       (resource: Resource): [string, Remote<Resource>] => [
@@ -165,7 +165,7 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return safeGet(this.entities, id);
   }
 
-  public concatResources(idProp: string, resources: Resource[]): Collection<Resource> {
+  public concatResources(idProp: keyof Resource, resources: Resource[]): Collection<Resource> {
     const col = new Collection(this);
 
     return resources.reduce((acc: Collection<Resource>, resource: Resource) => {
@@ -173,7 +173,7 @@ export default class Collection<Resource extends { [key: string]: any }> {
     }, col);
   }
 
-  public concat(idProp: string, other: Collection<Resource>): Collection<Resource> {
+  public concat(idProp: keyof Resource, other: Collection<Resource>): Collection<Resource> {
     const col = new Collection<Resource>(this);
 
     return other

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,14 @@ import { array } from 'fp-ts/lib/Array';
 import { ById, Remote, RemoteList, RemoteById } from './types';
 import { safeGet } from './utils';
 
+export const URI = '@cala/remote-collection';
+export type URI = typeof URI;
+declare module 'fp-ts/lib/HKT' {
+  interface URI2HKT1<A> {
+    '@cala/remote-collection': RemoteCollection<A>;
+  }
+}
+
 const view = <A>(entities: RemoteById<A>, ids: string[]): RemoteList<A> => {
   const s = sequence(RD.remoteData, array);
 
@@ -21,19 +29,22 @@ const view = <A>(entities: RemoteById<A>, ids: string[]): RemoteList<A> => {
   );
 };
 
-export default class Collection<Resource extends { [key: string]: any }> {
+export default class RemoteCollection<Resource extends { [key: string]: any }> {
+  readonly _A!: Resource;
+  readonly _URI!: URI;
+
   public knownIds: RemoteList<string> = RD.initial;
   public entities: ById<Remote<Resource>> = {};
 
-  constructor(fromCollection?: Collection<Resource>) {
+  constructor(fromCollection?: RemoteCollection<Resource>) {
     if (fromCollection) {
       this.knownIds = fromCollection.knownIds.map(ids => ids.slice());
       this.entities = { ...fromCollection.entities };
     }
   }
 
-  public refresh(): Collection<Resource> {
-    const col = new Collection(this);
+  public refresh(): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     col.knownIds = col.knownIds.toOption().fold<RemoteList<string>>(RD.pending, RD.refresh);
     col.entities = mapValues<RemoteById<Resource>, Remote<Resource>>(
       col.entities,
@@ -44,8 +55,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public withList(idProp: string, list: Resource[]): Collection<Resource> {
-    const col = new Collection(this);
+  public withList(idProp: string, list: Resource[]): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     const idsAndSuccesses: [string, Remote<Resource>][] = list.map(
       (resource: Resource): [string, Remote<Resource>] => [
         resource[idProp],
@@ -58,16 +69,16 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public withListFailure(error: string): Collection<Resource> {
-    const col = new Collection(this);
+  public withListFailure(error: string): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     col.knownIds = RD.failure([error]);
     col.entities = {};
 
     return col;
   }
 
-  public fetch(id: string): Collection<Resource> {
-    const col = new Collection(this);
+  public fetch(id: string): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     const currentValue = safeGet(this.entities, id);
     col.entities = {
       ...this.entities,
@@ -79,8 +90,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public withResource(id: string, resource: Resource): Collection<Resource> {
-    const col = new Collection(this);
+  public withResource(id: string, resource: Resource): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     col.knownIds = this.concatKnownId(id);
     col.entities = {
       ...this.entities,
@@ -93,8 +104,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
   public mapResource(
     id: string,
     mapFunction: (resource: Resource) => Resource
-  ): Collection<Resource> {
-    const col = new Collection(this);
+  ): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
 
     const existingResource = col.entities[id];
     if (!existingResource) {
@@ -109,8 +120,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public withResourceFailure(id: string, error: string): Collection<Resource> {
-    const col = new Collection(this);
+  public withResourceFailure(id: string, error: string): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     col.knownIds = this.concatKnownId(id);
     col.entities = {
       ...this.entities,
@@ -120,8 +131,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public remove(id: string): Collection<Resource> {
-    const col = new Collection(this);
+  public remove(id: string): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
     col.knownIds = this.knownIds.map(ids => without(ids, id));
     col.entities = omit(this.entities, id);
 
@@ -154,12 +165,21 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return safeGet(this.entities, id);
   }
 
-  public concatResources(idProp: string, resources: Resource[]): Collection<Resource> {
-    const col = new Collection(this);
+  public concatResources(idProp: string, resources: Resource[]): RemoteCollection<Resource> {
+    const col = new RemoteCollection(this);
 
-    return resources.reduce((acc: Collection<Resource>, resource: Resource) => {
+    return resources.reduce((acc: RemoteCollection<Resource>, resource: Resource) => {
       return acc.withResource(resource[idProp], resource);
     }, col);
+  }
+
+  public concat(idProp: string, other: RemoteCollection<Resource>): RemoteCollection<Resource> {
+    const col = new RemoteCollection<Resource>(this);
+
+    return other
+      .view()
+      .toOption()
+      .fold(col, (bResources: Resource[]) => col.concatResources(idProp, bResources));
   }
 
   private concatKnownId(id: string): RemoteList<string> {


### PR DESCRIPTION
In order to support prepending, this is a pretty straightforward array-like concatenation. It's linear, so it's not great, but that's how it goes with arrays.

~~Sorry for the renaming noise, I've been meaning to change `Collection` -> `RemoteCollection` for some time now, so I figured I'd just go ahead and do it.~~ Decided against this in the end.