### PR TITLE
Add map method to collection

### DIFF
--- a/src/__tests__/map.ts
+++ b/src/__tests__/map.ts
@@ -3,7 +3,7 @@ import * as RD from '@cala/remote-data';
 import Collection from '../index';
 import { Item, items } from './fixtures';
 
-const loudFoo = (item: Item) => ({ id: item.id, foo: item.foo.toUpperCase() });
+const loudFoo = (item: Item) => ({ ...item, loud: item.foo.toUpperCase() });
 
 test('with no items loaded, #map', t => {
   const col = new Collection<Item>().map(loudFoo);
@@ -21,8 +21,8 @@ test('with items loaded, #map', t => {
   t.deepEqual(
     col.entities,
     {
-      a: RD.success<string[], Item>({ id: 'a', foo: 'BAR' }),
-      b: RD.success<string[], Item>({ id: 'b', foo: 'BAZ' })
+      a: RD.success<string[], any>({ id: 'a', foo: 'bar', loud: 'BAR' }),
+      b: RD.success<string[], any>({ id: 'b', foo: 'baz', loud: 'BAZ' })
     },
     'applies map function to each item'
   );

--- a/src/__tests__/map.ts
+++ b/src/__tests__/map.ts
@@ -1,0 +1,39 @@
+import test from 'ava';
+import * as RD from '@cala/remote-data';
+import Collection from '../index';
+import { Item, items } from './fixtures';
+
+const loudFoo = (item: Item) => ({ id: item.id, foo: item.foo.toUpperCase() });
+
+test('with no items loaded, #map', t => {
+  const col = new Collection<Item>().map(loudFoo);
+  t.deepEqual(col.knownIds, RD.initial, 'sets knownIds to returned id');
+  t.deepEqual(col.entities, {}, 'sets entities to { [id: string]: RemoteSuccess(Item) }');
+});
+
+test('with items loaded, #map', t => {
+  const col = new Collection<Item>().withList('id', items).map(loudFoo);
+  t.deepEqual(
+    col.knownIds,
+    RD.success<string[], string[]>(['a', 'b']),
+    'sets knownIds to returned ids'
+  );
+  t.deepEqual(
+    col.entities,
+    {
+      a: RD.success<string[], Item>({ id: 'a', foo: 'BAR' }),
+      b: RD.success<string[], Item>({ id: 'b', foo: 'BAZ' })
+    },
+    'applies map function to each item'
+  );
+});
+
+test('with item loading failure, #map', t => {
+  const col = new Collection<Item>().withListFailure('Failed').map(loudFoo);
+  t.deepEqual(col.knownIds, RD.failure<string[], string[]>(['Failed']), 'sets knownIds to failure');
+  t.deepEqual(
+    col.entities,
+    {},
+    'sets entities to { [id: string]: RemoteSuccess(Item) } no changes'
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,16 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
+  public map(mapFunction: (resource: Resource) => Resource): Collection<Resource> {
+    const col = new Collection(this);
+    col.entities = mapValues<RemoteById<Resource>, Remote<Resource>>(
+      col.entities,
+      (entity: Remote<Resource> | undefined) => (entity ? entity.map(mapFunction) : RD.initial)
+    );
+
+    return col;
+  }
+
   public mapResource(
     id: string,
     mapFunction: (resource: Resource) => Resource

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,10 +101,11 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public map(mapFunction: (resource: Resource) => Resource): Collection<Resource> {
-    const col = new Collection(this);
-    col.entities = mapValues<RemoteById<Resource>, Remote<Resource>>(
-      col.entities,
+  public map<B>(mapFunction: (resource: Resource) => B): Collection<B> {
+    const col = new Collection<B>();
+    col.knownIds = this.knownIds.map(ids => ids.slice());
+    col.entities = mapValues<RemoteById<Resource>, Remote<B>>(
+      this.entities,
       (entity: Remote<Resource> | undefined) => (entity ? entity.map(mapFunction) : RD.initial)
     );
 


### PR DESCRIPTION
Realized we have a `mapResource` method that allows you to apply a function to a single resource, but nothing to transform all of the resources in a collection.