### PR TITLE
Downgrade fp-ts to support TS@2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,9 +1723,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.12.3.tgz",
-      "integrity": "sha512-0l3UGPhoU8tn8xu7xZviis09iulDtQK7yE594dEFMdgT+RovdlRhJRCEupFgKxHQjvgghG+y907psuKiW28sjA=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.8.1.tgz",
+      "integrity": "sha512-hcNjU4yFw2j0vqqTxJTptHAagA9KN5iaETmYGyMkoQcJzblVWq+7jEJdMy0CfJtVMjzTJn0sZIg+3Rfb+sAy4A=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2363,7 +2363,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -2692,7 +2692,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -3655,7 +3655,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -3729,7 +3729,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@cala/remote-data": "^0.1.1",
-    "fp-ts": "^1.12.3",
+    "fp-ts": "^1.8.1",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.11"
   }


### PR DESCRIPTION
Newer versions of `fp-ts` require TS@3, and I want to maintain compatibility with TS@2 without needing a shim. Also ran into some issues with the TypeScript compiler running out of memory using 0.5.0, so hopefully this fixes that.