### PR TITLE
Add array and null casting methods

### DIFF
--- a/src/__tests__/as-array.ts
+++ b/src/__tests__/as-array.ts
@@ -1,0 +1,45 @@
+import test from 'ava';
+import Collection from '../index';
+import { Item, items } from './fixtures';
+
+test('with no items loaded, #viewAsArray with no passed IDs', t => {
+  const col = new Collection<Item>();
+  t.deepEqual(col.viewAsArray(), [], 'returns an empty array');
+});
+
+test('with no items loaded, #view with invalid IDs', t => {
+  const col = new Collection<Item>();
+  t.deepEqual(col.viewAsArray(['x', 'y', 'z']), [], 'returns an empty array');
+});
+
+test('with item loading errors, #view with no passed IDs', t => {
+  const col = new Collection<Item>().withListFailure('There was a problem loading the list');
+  t.deepEqual(col.viewAsArray(), [], 'returns an empty array');
+});
+
+test('with item loading errors, #view with IDs', t => {
+  const col = new Collection<Item>().withListFailure('There was a problem loading the list');
+  t.deepEqual(col.viewAsArray(['a']), [], 'returns an empty array');
+});
+
+test('with items loaded, #view with no passed IDs', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.viewAsArray(), items, 'returns all known items');
+});
+
+test('with items loaded, #view with valid IDs', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.viewAsArray(['a', 'b']), items, 'returns subset');
+  t.deepEqual(
+    col.viewAsArray(['b', 'a']),
+    [items[1], items[0]],
+    'returns subset in order requested'
+  );
+  t.deepEqual(col.viewAsArray(['b']), [items[1]], 'returns a single item array');
+});
+
+test('with items loaded, #view with invalid IDs', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.viewAsArray(['x', 'y']), [], 'returns an empty array');
+  t.deepEqual(col.viewAsArray(['z']), [], 'returns an empty array');
+});

--- a/src/__tests__/as-array.ts
+++ b/src/__tests__/as-array.ts
@@ -7,27 +7,27 @@ test('with no items loaded, #viewAsArray with no passed IDs', t => {
   t.deepEqual(col.viewAsArray(), [], 'returns an empty array');
 });
 
-test('with no items loaded, #view with invalid IDs', t => {
+test('with no items loaded, #viewAsArray with invalid IDs', t => {
   const col = new Collection<Item>();
   t.deepEqual(col.viewAsArray(['x', 'y', 'z']), [], 'returns an empty array');
 });
 
-test('with item loading errors, #view with no passed IDs', t => {
+test('with item loading errors, #viewAsArray with no passed IDs', t => {
   const col = new Collection<Item>().withListFailure('There was a problem loading the list');
   t.deepEqual(col.viewAsArray(), [], 'returns an empty array');
 });
 
-test('with item loading errors, #view with IDs', t => {
+test('with item loading errors, #viewAsArray with IDs', t => {
   const col = new Collection<Item>().withListFailure('There was a problem loading the list');
   t.deepEqual(col.viewAsArray(['a']), [], 'returns an empty array');
 });
 
-test('with items loaded, #view with no passed IDs', t => {
+test('with items loaded, #viewAsArray with no passed IDs', t => {
   const col = new Collection<Item>().withList('id', items);
   t.deepEqual(col.viewAsArray(), items, 'returns all known items');
 });
 
-test('with items loaded, #view with valid IDs', t => {
+test('with items loaded, #viewAsArray with valid IDs', t => {
   const col = new Collection<Item>().withList('id', items);
   t.deepEqual(col.viewAsArray(['a', 'b']), items, 'returns subset');
   t.deepEqual(
@@ -38,8 +38,13 @@ test('with items loaded, #view with valid IDs', t => {
   t.deepEqual(col.viewAsArray(['b']), [items[1]], 'returns a single item array');
 });
 
-test('with items loaded, #view with invalid IDs', t => {
+test('with items loaded, #viewAsArray with invalid IDs', t => {
   const col = new Collection<Item>().withList('id', items);
   t.deepEqual(col.viewAsArray(['x', 'y']), [], 'returns an empty array');
   t.deepEqual(col.viewAsArray(['z']), [], 'returns an empty array');
+});
+
+test('with items loaded, #viewAsArray with valid and invalid IDs', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.viewAsArray(['a', 'x', 'y']), [items[0]], 'returns the valid one');
 });

--- a/src/__tests__/as-nullable.ts
+++ b/src/__tests__/as-nullable.ts
@@ -1,0 +1,18 @@
+import test from 'ava';
+import Collection from '../index';
+import { Item, items } from './fixtures';
+
+test('with no items loaded, #findAsNullable', t => {
+  const col = new Collection<Item>();
+  t.deepEqual(col.findAsNullable('a'), null, 'returns null');
+});
+
+test('with items loaded, #findAsNullable with valid ID', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.findAsNullable('a'), items[0], 'returns item');
+});
+
+test('with items loaded, #findAsNullable with invalid ID', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.findAsNullable('z'), null, 'returns null');
+});

--- a/src/__tests__/at.ts
+++ b/src/__tests__/at.ts
@@ -216,3 +216,20 @@ test('#viewAt, with a some successes and a failure', t => {
     'Returns the successful items'
   );
 });
+
+test('#viewAtAsArray, with items loaded', t => {
+  const col = new Collection<Item>().withListAt('parentId', 'id', items);
+  t.deepEqual(col.viewAtAsArray('parentId'), [items[0], items[1]], 'Returns the successful items');
+});
+
+test('#viewAtAsArray, with no items loaded', t => {
+  const col = new Collection<Item>();
+  t.deepEqual(col.viewAtAsArray('parentId'), [], 'Returns initial');
+});
+
+test('#viewAtAsArray, with a some successes and a failure', t => {
+  const col = new Collection<Item>()
+    .withListAt('parentId', 'id', items)
+    .withResourceFailureAt('parentId', 'c', 'Something went wrong!');
+  t.deepEqual(col.viewAtAsArray('parentId'), [], 'Returns the successful items');
+});

--- a/src/__tests__/view.ts
+++ b/src/__tests__/view.ts
@@ -52,3 +52,8 @@ test('with items loaded, #view with invalid IDs', t => {
   t.deepEqual(col.view(['x', 'y']), RD.success([]), 'returns an empty success');
   t.deepEqual(col.view(['z']), RD.success([]), 'returns an empty success');
 });
+
+test('with items loaded, #view with valid and invalid IDs', t => {
+  const col = new Collection<Item>().withList('id', items);
+  t.deepEqual(col.view(['a', 'x', 'y']), RD.success([items[0]]), 'returns an empty success');
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,17 @@ export default class Collection<Resource extends { [key: string]: any }> {
   public find(id: string): Remote<Resource> {
     return safeGet(this.entities, id).getOrElse(RD.initial);
   }
+  public viewAsArray(ids?: string[]): Resource[] {
+    return this.view(ids).getOrElse([]);
+  }
+
+  public viewAtAsArray(at: string): Resource[] {
+    return this.viewAt(at).getOrElse([]);
+  }
+
+  public findAsNullable(id: string): Resource | null {
+    return this.find(id).toNullable();
+  }
 
   public concatResources(idProp: keyof Resource, resources: Resource[]): Collection<Resource> {
     return resources.reduce(


### PR DESCRIPTION
Adds some helper methods to cast `Option`s and `RemoteData`s into the underlying primitives. Helps with some common patterns that have emerged.

## Find resource or get null
### Before
```ts
const resource = entityStore
  .find(fooId)
  .fold(null, (remoteFoo: RemoteData<string[], Foo>) =>
    remoteFoo.toOption().fold(null, (foo: Foo) => foo)
  );
```

### After
```ts
const resource = entityStore.findAsNullable(fooId);
```

## Get collection as an array
### Before
```ts
const resources = entityStore.view().getOrElse([]);
// or for child resources
const resources = entityStore.viewAt(parentId).getOrElse([]);
```

### After
```ts
const resources = entityStore.viewAsArray();
// or for child resources
const resources = entityStore.viewAtAsArray(parentId);
```