### PR TITLE
[BREAKING] find returns RemoteInitial if lookup fails

### DIFF
--- a/src/__tests__/find.ts
+++ b/src/__tests__/find.ts
@@ -1,20 +1,19 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import { some, none } from 'fp-ts/lib/Option';
 import Collection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #find', t => {
   const col = new Collection<Item>();
-  t.deepEqual(col.find('a'), none, 'returns None');
+  t.deepEqual(col.find('a'), RD.initial, 'returns RemoteInitial');
 });
 
 test('with items loaded, #find with valid ID', t => {
   const col = new Collection<Item>().withList('id', items);
-  t.deepEqual(col.find('a'), some(RD.success(items[0])), 'returns Some(Success(Item))');
+  t.deepEqual(col.find('a'), RD.success(items[0]), 'returns Success(Item)');
 });
 
 test('with items loaded, #find with invalid ID', t => {
   const col = new Collection<Item>().withList('id', items);
-  t.deepEqual(col.find('z'), none, 'returns None');
+  t.deepEqual(col.find('z'), RD.initial, 'returns RemoteInitial');
 });

--- a/src/__tests__/identity.ts
+++ b/src/__tests__/identity.ts
@@ -1,6 +1,5 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import { none } from 'fp-ts/lib/Option';
 import Collection from '../index';
 import { Item } from './fixtures';
 
@@ -9,5 +8,5 @@ test('internal data is not linked', t => {
   const copy = new Collection<Item>(col);
 
   col.entities['z'] = RD.success({ id: 'z', foo: 'zed' });
-  t.deepEqual(copy.find('z'), none);
+  t.deepEqual(copy.find('z'), RD.initial);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { fromPairs, mapValues, omit, union, without } from 'lodash';
 import * as RD from '@cala/remote-data';
 import { lookup, insert, StrMap, toArray } from 'fp-ts/lib/StrMap';
-import { Option } from 'fp-ts/lib/Option';
 import { sequence } from 'fp-ts/lib/Traversable';
 import { array } from 'fp-ts/lib/Array';
 
@@ -247,8 +246,8 @@ export default class Collection<Resource extends { [key: string]: any }> {
     });
   }
 
-  public find(id: string): Option<Remote<Resource>> {
-    return safeGet(this.entities, id);
+  public find(id: string): Remote<Resource> {
+    return safeGet(this.entities, id).getOrElse(RD.initial);
   }
 
   public concatResources(idProp: keyof Resource, resources: Resource[]): Collection<Resource> {


### PR DESCRIPTION
⚠️ Breaking Change ⚠️ 

We were always treating `None` as `RemoteInitial` in our code, so instead of requiring the extra casting and importing of `RemoteData`, change `find` to treat the "we do not have that entity" (`None`) case as "we have not gotten that entity" (`RemoteInitial`).

### Before
```ts
const resource = entityStore.find(fooId).getOrElse(RemoteData.initial);
```

### After
```ts
const resource entityStore.find(fooId);
```