### PR TITLE
Rename the class to RemoteCollection for consistency

### DIFF
--- a/src/__tests__/at.ts
+++ b/src/__tests__/at.ts
@@ -1,12 +1,12 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 const moreItems = [{ id: 'c', foo: 'test' }, { id: 'd', foo: 'test' }];
 
 test('#withListAt', t => {
-  const col = new Collection<Item>().withListAt('parentId', 'id', items);
+  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -28,7 +28,7 @@ test('#withListAt', t => {
 });
 
 test('#withListAt, twice', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withListAt('parentId', 'id', items)
     .withListAt('parentId', 'id', moreItems);
   t.deepEqual(
@@ -52,7 +52,7 @@ test('#withListAt, twice', t => {
 });
 
 test('#withListFailureAt', t => {
-  const col = new Collection<Item>().withListFailureAt('parentId', 'Something went wrong!');
+  const col = new RemoteCollection<Item>().withListFailureAt('parentId', 'Something went wrong!');
   t.deepEqual(
     col.knownIds,
     RD.failure<string[], string[]>(['Something went wrong!']),
@@ -67,7 +67,7 @@ test('#withListFailureAt', t => {
 });
 
 test('#withResourceAt, with no existing items', t => {
-  const col = new Collection<Item>().withResourceAt('parentId', items[0].id, items[0]);
+  const col = new RemoteCollection<Item>().withResourceAt('parentId', items[0].id, items[0]);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a']),
@@ -88,7 +88,7 @@ test('#withResourceAt, with no existing items', t => {
 });
 
 test('#withResourceAt, with existing items', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withResourceAt('parentId', items[0].id, items[0])
     .withResourceAt('parentId', items[1].id, items[1]);
   t.deepEqual(
@@ -112,7 +112,7 @@ test('#withResourceAt, with existing items', t => {
 });
 
 test('#withResourceFailureAt, with existing succesful items', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withResourceAt('parentId', items[0].id, items[0])
     .withResourceFailureAt('parentId', items[1].id, 'Something went wrong!');
   t.deepEqual(
@@ -136,14 +136,14 @@ test('#withResourceFailureAt, with existing succesful items', t => {
 });
 
 test('#removeAt, with no items loaded', t => {
-  const col = new Collection<Item>().removeAt('parentId', 'a');
+  const col = new RemoteCollection<Item>().removeAt('parentId', 'a');
   t.deepEqual(col.knownIds, RD.initial, 'Does not add to list of known IDs');
   t.deepEqual(col.idMap.value, {}, 'Does not add to ID map');
   t.deepEqual(col.entities, {}, 'Does not add to entity map');
 });
 
 test('#removeAt, with items loaded', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withListAt('parentId', 'id', items)
     .removeAt('parentId', 'a')
     .removeAt('parentId', 'notFound');
@@ -170,7 +170,7 @@ test('#removeAt, with items loaded', t => {
 });
 
 test('#refreshAt, with items loaded', t => {
-  const col = new Collection<Item>().withListAt('parentId', 'id', items).refreshAt('parentId');
+  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items).refreshAt('parentId');
   t.deepEqual(
     col.idMap.value,
     { parentId: RD.refresh<string[], string[]>(['a', 'b']) },
@@ -187,13 +187,13 @@ test('#refreshAt, with items loaded', t => {
 });
 
 test('#refreshAt, with no items loaded', t => {
-  const col = new Collection<Item>().refreshAt('parentId');
+  const col = new RemoteCollection<Item>().refreshAt('parentId');
   t.deepEqual(col.idMap.value, { parentId: RD.pending }, 'sets ID list at the key to pending');
   t.deepEqual(col.entities, {}, 'sets entities to { [id: string]: RemoteSuccess(Item) }');
 });
 
 test('#viewAt, with items loaded', t => {
-  const col = new Collection<Item>().withListAt('parentId', 'id', items);
+  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items);
   t.deepEqual(
     col.viewAt('parentId'),
     RD.success([items[0], items[1]]),
@@ -202,12 +202,12 @@ test('#viewAt, with items loaded', t => {
 });
 
 test('#viewAt, with no items loaded', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.deepEqual(col.viewAt('parentId'), RD.initial, 'Returns initial');
 });
 
 test('#viewAt, with a some successes and a failure', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withListAt('parentId', 'id', items)
     .withResourceFailureAt('parentId', 'c', 'Something went wrong!');
   t.deepEqual(

--- a/src/__tests__/concat-resources.ts
+++ b/src/__tests__/concat-resources.ts
@@ -1,12 +1,12 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 const moreItems = [{ id: 'c', foo: 'test' }, { id: 'd', foo: 'test' }];
 
 test('with no items loaded, #withList', t => {
-  const col = new Collection<Item>().withList('id', items).concatResources('id', moreItems);
+  const col = new RemoteCollection<Item>().withList('id', items).concatResources('id', moreItems);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b', 'c', 'd']),
@@ -25,7 +25,7 @@ test('with no items loaded, #withList', t => {
 });
 
 test('with item loading failure, #withList', t => {
-  const col = new Collection<Item>().withListFailure('Failed').concatResources('id', items);
+  const col = new RemoteCollection<Item>().withListFailure('Failed').concatResources('id', items);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),

--- a/src/__tests__/concat.ts
+++ b/src/__tests__/concat.ts
@@ -1,13 +1,13 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 const moreItems = [{ id: 'c', foo: 'test' }, { id: 'd', foo: 'test' }];
 
 test('with non-overlapping two collections', t => {
-  const other = new Collection<Item>().withList('id', moreItems);
-  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  const other = new RemoteCollection<Item>().withList('id', moreItems);
+  const col = new RemoteCollection<Item>().withList('id', items).concat('id', other);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b', 'c', 'd']),
@@ -26,10 +26,10 @@ test('with non-overlapping two collections', t => {
 });
 
 test('with two collections that have id maps', t => {
-  const other = new Collection<Item>()
+  const other = new RemoteCollection<Item>()
     .withListAt('parentId', 'id', moreItems)
     .withListAt('otherParentId', 'id', moreItems);
-  const col = new Collection<Item>().withListAt('parentId', 'id', items).concat('id', other);
+  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items).concat('id', other);
   t.deepEqual(
     col.idMap.value,
     {
@@ -56,8 +56,8 @@ test('with two collections that have id maps', t => {
 });
 
 test('with the same collection twice', t => {
-  const other = new Collection<Item>().withList('id', items);
-  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  const other = new RemoteCollection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items).concat('id', other);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']), 'does not update ids');
   t.deepEqual(
     col.entities,
@@ -70,8 +70,8 @@ test('with the same collection twice', t => {
 });
 
 test('with an empty collection', t => {
-  const other = new Collection<Item>();
-  const col = new Collection<Item>().withList('id', items).concat('id', other);
+  const other = new RemoteCollection<Item>();
+  const col = new RemoteCollection<Item>().withList('id', items).concat('id', other);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']), 'does not update ids');
   t.deepEqual(
     col.entities,

--- a/src/__tests__/constructor.ts
+++ b/src/__tests__/constructor.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import { initial, success } from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no initial data', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.truthy(col);
   t.deepEqual(col.knownIds, initial);
   t.deepEqual(col.idMap.value, {});
@@ -12,8 +12,8 @@ test('with no initial data', t => {
 });
 
 test('with initial data', t => {
-  const existing = new Collection<Item>().withList('id', items);
-  const col = new Collection<Item>(existing);
+  const existing = new RemoteCollection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>(existing);
 
   t.not(existing, col);
   t.deepEqual(col.knownIds, success(['a', 'b']));
@@ -26,8 +26,8 @@ test('with initial data', t => {
 
 test('with initial data with parent mapping', t => {
   // TODO where to put the parent id?
-  const existing = new Collection<Item>().withListAt('parentId', 'id', items);
-  const col = new Collection<Item>(existing);
+  const existing = new RemoteCollection<Item>().withListAt('parentId', 'id', items);
+  const col = new RemoteCollection<Item>(existing);
 
   t.not(existing, col);
   t.deepEqual(col.knownIds, success(['a', 'b']));

--- a/src/__tests__/fetch.ts
+++ b/src/__tests__/fetch.ts
@@ -1,22 +1,22 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #fetch', t => {
-  const col = new Collection<Item>().fetch('a');
+  const col = new RemoteCollection<Item>().fetch('a');
   t.deepEqual(col.entities, { a: RD.pending }, 'transitions id to pending');
 });
 
 test('with item loading failure, #fetch', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withListFailure('There was a problem getting the list')
     .fetch('a');
   t.deepEqual(col.entities, { a: RD.pending }, 'transitions id to pending');
 });
 
 test('with items loaded, #fetch', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.entities, {
     a: RD.success<string[], Item>(items[0]),
     b: RD.success<string[], Item>(items[1])

--- a/src/__tests__/find.ts
+++ b/src/__tests__/find.ts
@@ -1,19 +1,19 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #find', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.deepEqual(col.find('a'), RD.initial, 'returns RemoteInitial');
 });
 
 test('with items loaded, #find with valid ID', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.find('a'), RD.success(items[0]), 'returns Success(Item)');
 });
 
 test('with items loaded, #find with invalid ID', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.find('z'), RD.initial, 'returns RemoteInitial');
 });

--- a/src/__tests__/identity.ts
+++ b/src/__tests__/identity.ts
@@ -1,11 +1,11 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item } from './fixtures';
 
 test('internal data is not linked', t => {
-  const col = new Collection<Item>();
-  const copy = new Collection<Item>(col);
+  const col = new RemoteCollection<Item>();
+  const copy = new RemoteCollection<Item>(col);
 
   col.entities['z'] = RD.success({ id: 'z', foo: 'zed' });
   t.deepEqual(copy.find('z'), RD.initial);

--- a/src/__tests__/map-resource.ts
+++ b/src/__tests__/map-resource.ts
@@ -1,18 +1,18 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 const identityMap = (a: any): any => a;
 
 test('with no items loaded, #mapResource', t => {
-  const col = new Collection<Item>().mapResource('a', identityMap);
+  const col = new RemoteCollection<Item>().mapResource('a', identityMap);
   t.deepEqual(col.knownIds, RD.initial, 'sets knownIds to returned id');
   t.deepEqual(col.entities, {}, 'sets entities to { [id: string]: RemoteSuccess(Item) }');
 });
 
 test('with items loaded, #mapResource on an existing ID', t => {
-  const col = new Collection<Item>().withList('id', items).mapResource('a', identityMap);
+  const col = new RemoteCollection<Item>().withList('id', items).mapResource('a', identityMap);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -29,7 +29,7 @@ test('with items loaded, #mapResource on an existing ID', t => {
 });
 
 test('with items loaded, #mapResource on an unknown ID', t => {
-  const col = new Collection<Item>().withList('id', items).mapResource('z', identityMap);
+  const col = new RemoteCollection<Item>().withList('id', items).mapResource('z', identityMap);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -46,7 +46,7 @@ test('with items loaded, #mapResource on an unknown ID', t => {
 });
 
 test('with item loading failure, #mapResource', t => {
-  const col = new Collection<Item>().withListFailure('Failed').mapResource('a', identityMap);
+  const col = new RemoteCollection<Item>().withListFailure('Failed').mapResource('a', identityMap);
   t.deepEqual(col.knownIds, RD.failure<string[], string[]>(['Failed']), 'sets knownIds to failure');
   t.deepEqual(
     col.entities,

--- a/src/__tests__/refresh.ts
+++ b/src/__tests__/refresh.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #refresh', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.deepEqual(col.knownIds, RD.initial);
   const refreshed = col.refresh();
   t.deepEqual(refreshed.knownIds, RD.pending, 'transitions knownIds to pending');
@@ -12,14 +12,14 @@ test('with no items loaded, #refresh', t => {
 });
 
 test('with item loading failure, #refresh', t => {
-  const col = new Collection<Item>().withListFailure('There was a problem getting the list');
+  const col = new RemoteCollection<Item>().withListFailure('There was a problem getting the list');
   const refreshed = col.refresh();
   t.deepEqual(refreshed.knownIds, RD.pending, 'transitions knownIds to pending');
   t.deepEqual(refreshed.entities, {}, 'do not update entities');
 });
 
 test('with items loaded, #refresh', t => {
-  const col = new Collection<Item>().withList('id', items).withResourceFailure('b', 'Failed');
+  const col = new RemoteCollection<Item>().withList('id', items).withResourceFailure('b', 'Failed');
   t.deepEqual(col.knownIds, RD.success(['a', 'b']));
   const refreshed = col.refresh();
   t.deepEqual(refreshed.knownIds, RD.refresh(['a', 'b']), 'transitions knownIds to refresh');

--- a/src/__tests__/remove.ts
+++ b/src/__tests__/remove.ts
@@ -1,16 +1,16 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #remove', t => {
-  const col = new Collection<Item>().remove('a');
+  const col = new RemoteCollection<Item>().remove('a');
   t.deepEqual(col.knownIds, RD.initial, 'does not update knownIds');
   t.deepEqual(col.entities, {}, 'removes entity from entity map');
 });
 
 test('with items loaded, #remove on an existing ID', t => {
-  const col = new Collection<Item>().withList('id', items).remove('a');
+  const col = new RemoteCollection<Item>().withList('id', items).remove('a');
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['b']),
@@ -24,7 +24,7 @@ test('with items loaded, #remove on an existing ID', t => {
 });
 
 test('with items loaded, #remove on an unknown ID', t => {
-  const col = new Collection<Item>().withList('id', items).remove('z');
+  const col = new RemoteCollection<Item>().withList('id', items).remove('z');
   const removed = col.remove('z');
   t.not(col, removed, 'returns a copy');
   t.deepEqual(removed.knownIds, RD.success<string[], string[]>(['a', 'b']), 'is a no-op');
@@ -39,7 +39,7 @@ test('with items loaded, #remove on an unknown ID', t => {
 });
 
 test('with item loading failure, #remove', t => {
-  const col = new Collection<Item>().withListFailure('Failed');
+  const col = new RemoteCollection<Item>().withListFailure('Failed');
   const removed = col.remove('a');
   t.not(col, removed, 'returns a copy');
   t.deepEqual(col.knownIds, RD.failure(['Failed']), 'is a no-op');

--- a/src/__tests__/view.ts
+++ b/src/__tests__/view.ts
@@ -1,20 +1,20 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #view with no passed IDs', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.deepEqual(col.view(), RD.initial, 'returns initial');
 });
 
 test('with no items loaded, #view with invalid IDs', t => {
-  const col = new Collection<Item>();
+  const col = new RemoteCollection<Item>();
   t.deepEqual(col.view(['x', 'y', 'z']), RD.initial, 'returns initial');
 });
 
 test('with item loading errors, #view with no passed IDs', t => {
-  const col = new Collection<Item>().withListFailure('There was a problem loading the list');
+  const col = new RemoteCollection<Item>().withListFailure('There was a problem loading the list');
   t.deepEqual(
     col.view(),
     RD.failure(['There was a problem loading the list']),
@@ -23,7 +23,7 @@ test('with item loading errors, #view with no passed IDs', t => {
 });
 
 test('with item loading errors, #view with IDs', t => {
-  const col = new Collection<Item>().withListFailure('There was a problem loading the list');
+  const col = new RemoteCollection<Item>().withListFailure('There was a problem loading the list');
   t.deepEqual(
     col.view(['a']),
     RD.failure(['There was a problem loading the list']),
@@ -32,12 +32,12 @@ test('with item loading errors, #view with IDs', t => {
 });
 
 test('with items loaded, #view with no passed IDs', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.view(), RD.success(items), 'returns all known items');
 });
 
 test('with items loaded, #view with valid IDs', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.view(['a', 'b']), RD.success(items), 'returns subset');
   t.deepEqual(
     col.view(['b', 'a']),
@@ -48,7 +48,7 @@ test('with items loaded, #view with valid IDs', t => {
 });
 
 test('with items loaded, #view with invalid IDs', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(col.view(['x', 'y']), RD.success([]), 'returns an empty success');
   t.deepEqual(col.view(['z']), RD.success([]), 'returns an empty success');
 });

--- a/src/__tests__/with-list-failure.ts
+++ b/src/__tests__/with-list-failure.ts
@@ -1,22 +1,22 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withListFailure', t => {
-  const col = new Collection<Item>().withListFailure('Failed');
+  const col = new RemoteCollection<Item>().withListFailure('Failed');
   t.deepEqual(col.knownIds, RD.failure(['Failed']), 'sets knownIds to failure');
   t.deepEqual(col.entities, {}, 'does not update entities');
 });
 
 test('with items loaded, #withList', t => {
-  const col = new Collection<Item>().withListFailure('Failed');
+  const col = new RemoteCollection<Item>().withListFailure('Failed');
   t.deepEqual(col.knownIds, RD.failure(['Failed']), 'sets knownIds to failure');
   t.deepEqual(col.entities, {}, 'does not update entities');
 });
 
 test('with item loading failure, #withList', t => {
-  const col = new Collection<Item>().withList('id', items).withListFailure('Failed');
+  const col = new RemoteCollection<Item>().withList('id', items).withListFailure('Failed');
   t.deepEqual(col.knownIds, RD.failure(['Failed']), 'sets knownIds to failure');
   t.deepEqual(col.entities, {}, 'does not update entities');
 });

--- a/src/__tests__/with-list.ts
+++ b/src/__tests__/with-list.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withList', t => {
-  const col = new Collection<Item>().withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -18,7 +18,7 @@ test('with no items loaded, #withList', t => {
 });
 
 test('with items loaded, #withList', t => {
-  const col = new Collection<Item>().withList('id', items).withList('id', items);
+  const col = new RemoteCollection<Item>().withList('id', items).withList('id', items);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -32,7 +32,7 @@ test('with items loaded, #withList', t => {
 });
 
 test('with item loading failure, #withList', t => {
-  const col = new Collection<Item>().withListFailure('Failed').withList('id', items);
+  const col = new RemoteCollection<Item>().withListFailure('Failed').withList('id', items);
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),

--- a/src/__tests__/with-resource-failure.ts
+++ b/src/__tests__/with-resource-failure.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withResourceFailure', t => {
-  const col = new Collection<Item>().withResourceFailure('a', 'Failed');
+  const col = new RemoteCollection<Item>().withResourceFailure('a', 'Failed');
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,
@@ -14,7 +14,7 @@ test('with no items loaded, #withResourceFailure', t => {
 });
 
 test('with items loaded, #withResourceFailure on an existing ID', t => {
-  const col = new Collection<Item>().withList('id', items).withResourceFailure('a', 'Failed');
+  const col = new RemoteCollection<Item>().withList('id', items).withResourceFailure('a', 'Failed');
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b']),
@@ -31,7 +31,7 @@ test('with items loaded, #withResourceFailure on an existing ID', t => {
 });
 
 test('with items loaded, #withResourceFailure on an unknown ID', t => {
-  const col = new Collection<Item>().withList('id', items).withResourceFailure('z', 'Failed');
+  const col = new RemoteCollection<Item>().withList('id', items).withResourceFailure('z', 'Failed');
   t.deepEqual(
     col.knownIds,
     RD.success<string[], string[]>(['a', 'b', 'z']),
@@ -49,7 +49,9 @@ test('with items loaded, #withResourceFailure on an unknown ID', t => {
 });
 
 test('with item loading failure, #withResourceFailure', t => {
-  const col = new Collection<Item>().withListFailure('Failed').withResourceFailure('a', 'Failed');
+  const col = new RemoteCollection<Item>()
+    .withListFailure('Failed')
+    .withResourceFailure('a', 'Failed');
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,

--- a/src/__tests__/with-resource.ts
+++ b/src/__tests__/with-resource.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
 import * as RD from '@cala/remote-data';
-import Collection from '../index';
+import RemoteCollection from '../index';
 import { Item, items } from './fixtures';
 
 test('with no items loaded, #withResource', t => {
-  const col = new Collection<Item>().withResource('a', items[0]);
+  const col = new RemoteCollection<Item>().withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,
@@ -14,7 +14,7 @@ test('with no items loaded, #withResource', t => {
 });
 
 test('with items loaded, #withResource on an existing ID', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withList('id', items)
     .withResource('a', { id: 'a', foo: 'quux' });
   t.deepEqual(
@@ -33,7 +33,7 @@ test('with items loaded, #withResource on an existing ID', t => {
 });
 
 test('with items loaded, #withResource on an unknown ID', t => {
-  const col = new Collection<Item>()
+  const col = new RemoteCollection<Item>()
     .withList('id', items)
     .withResource('z', { id: 'z', foo: 'zed' });
   t.deepEqual(
@@ -53,7 +53,7 @@ test('with items loaded, #withResource on an unknown ID', t => {
 });
 
 test('with item loading failure, #withResource', t => {
-  const col = new Collection<Item>().withListFailure('Failed').withResource('a', items[0]);
+  const col = new RemoteCollection<Item>().withListFailure('Failed').withResource('a', items[0]);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a']), 'sets knownIds to returned id');
   t.deepEqual(
     col.entities,


### PR DESCRIPTION
This is backwards compatible since it's the `default` export, but it's been bugging me for a while that the name has been off. We used both freely in the tests, so aligned those, too.