### PR TITLE
Do not clear collection when using withListAt and withListFailureAt

### DIFF
--- a/src/__tests__/at.ts
+++ b/src/__tests__/at.ts
@@ -30,20 +30,26 @@ test('#withListAt', t => {
 test('#withListAt, twice', t => {
   const col = new RemoteCollection<Item>()
     .withListAt('parentId', 'id', items)
+    .withListAt('otherParentId', 'id', items)
     .withListAt('parentId', 'id', moreItems);
   t.deepEqual(
     col.knownIds,
-    RD.success<string[], string[]>(['c', 'd']),
+    RD.success<string[], string[]>(['a', 'b', 'c', 'd']),
     'Replaces the known IDs property to new IDs'
   );
   t.deepEqual(
     col.idMap.value,
-    { parentId: RD.success<string[], string[]>(['c', 'd']) },
+    {
+      parentId: RD.success<string[], string[]>(['c', 'd']),
+      otherParentId: RD.success<string[], string[]>(['a', 'b'])
+    },
     'Replaces the values at the given key in ID Map to new IDs'
   );
   t.deepEqual(
     col.entities,
     {
+      a: RD.success<string[], Item>(items[0]),
+      b: RD.success<string[], Item>(items[1]),
       c: RD.success<string[], Item>(moreItems[0]),
       d: RD.success<string[], Item>(moreItems[1])
     },
@@ -170,7 +176,9 @@ test('#removeAt, with items loaded', t => {
 });
 
 test('#refreshAt, with items loaded', t => {
-  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items).refreshAt('parentId');
+  const col = new RemoteCollection<Item>()
+    .withListAt('parentId', 'id', items)
+    .refreshAt('parentId');
   t.deepEqual(
     col.idMap.value,
     { parentId: RD.refresh<string[], string[]>(['a', 'b']) },
@@ -215,4 +223,9 @@ test('#viewAt, with a some successes and a failure', t => {
     RD.failure(['Something went wrong!']),
     'Returns the successful items'
   );
+});
+
+test('#viewAt, with a some successes and a removed item', t => {
+  const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items).remove('b');
+  t.deepEqual(col.viewAt('parentId'), RD.success([items[0]]), 'Returns the successful items');
 });

--- a/src/__tests__/at.ts
+++ b/src/__tests__/at.ts
@@ -58,18 +58,30 @@ test('#withListAt, twice', t => {
 });
 
 test('#withListFailureAt', t => {
-  const col = new RemoteCollection<Item>().withListFailureAt('parentId', 'Something went wrong!');
+  const col = new RemoteCollection<Item>()
+    .withListAt('otherParentId', 'id', items)
+    .withListFailureAt('parentId', 'Something went wrong!');
   t.deepEqual(
     col.knownIds,
-    RD.failure<string[], string[]>(['Something went wrong!']),
-    'Saves the failure message to the list'
+    RD.success<string[], string[]>(['a', 'b']),
+    'Does not remove successful known IDs'
   );
   t.deepEqual(
     col.idMap.value,
-    { parentId: RD.failure<string[], string[]>(['Something went wrong!']) },
+    {
+      parentId: RD.failure<string[], string[]>(['Something went wrong!']),
+      otherParentId: RD.success<string[], string[]>(['a', 'b'])
+    },
     'Saves the failure message at the given key'
   );
-  t.deepEqual(col.entities, {}, 'Does not insert any new entities');
+  t.deepEqual(
+    col.entities,
+    {
+      a: RD.success<string[], Item>(items[0]),
+      b: RD.success<string[], Item>(items[1])
+    },
+    'Does not remove existing entities'
+  );
 });
 
 test('#withResourceAt, with no existing items', t => {

--- a/src/__tests__/at.ts
+++ b/src/__tests__/at.ts
@@ -237,7 +237,7 @@ test('#viewAt, with a some successes and a failure', t => {
   );
 });
 
-test('#viewAt, with a some successes and a removed item', t => {
+test('#viewAt, with some successes and a removed item', t => {
   const col = new RemoteCollection<Item>().withListAt('parentId', 'id', items).remove('b');
   t.deepEqual(col.viewAt('parentId'), RD.success([items[0]]), 'Returns the successful items');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,10 @@ export default class RemoteCollection<Resource extends { [key: string]: any }> {
   }
 
   public withListFailureAt(at: string, error: string): RemoteCollection<Resource> {
-    const col = this.withListFailure(error);
+    const col = new RemoteCollection(this);
+
     col.idMap = insert(at, RD.failure([error]), col.idMap);
+
     return col;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,10 +86,13 @@ export default class RemoteCollection<Resource extends { [key: string]: any }> {
     idProp: keyof Resource,
     list: Resource[]
   ): RemoteCollection<Resource> {
-    const col = this.withList(idProp, list);
-    const ids = RD.success<string[], string[]>(list.map(resource => resource[idProp]));
-    col.idMap = insert(at, ids, col.idMap);
-    return col;
+    const col = new RemoteCollection(this);
+
+    const resourceIds: string[] = list.map((resource: Resource): string => resource[idProp]);
+    const newIds = RD.success<string[], string[]>(resourceIds);
+
+    col.idMap = insert(at, newIds, col.idMap);
+    return col.concatResources(idProp, list);
   }
 
   public withList(idProp: keyof Resource, list: Resource[]): RemoteCollection<Resource> {


### PR DESCRIPTION
Previously we were calling `withList` and `withListFailure` under the hood which had the effect of removing the existing entities that were in the store! 😱 