### PR TITLE
README updates to API for discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,25 @@ to account for, etc.
 
 `remote-collection` is here to help with that!
 
-## RemoteCollection
+## Normalization
+
+The same set of resources might have different ordering, be a filtered set, or
+some other smaller subset of the overall set. We call these subsets "views". One
+of the requirements of a resource is that it is _identifiable_ by some property.
+Typically an `id`, `uri`, `href`, or similar property. The set of those
+identified resources are normalized such that updates to that resource should be
+visible to other views that might include it.
+
+## Remote
+
+The state of fetching the whole collection, and the state of each individual
+resource are possiblity divergent, so `RemoteCollection` stores those states
+separately. You may have a failure state in one of your resources, but are
+refetching the whole list, and `RemoteCollection` tracks both states.
+
+# Usage
+
+## RemoteCollection (Constructor)
 
 Creates a new `RemoteCollection` of a generic `Resource` type. If you pass in
 another `RemoteCollection<Resource>` to the constructor, it will merge the
@@ -52,12 +70,14 @@ const collection = new RemoteCollection<User>();
 const merged = new RemoteCollection<User>(collection);
 ```
 
+# Resource Methods
+
 ## fetch
 
 Sets the resource at the given ID to `RemotePending`, or if it is already a
 `RemoteSuccess` or `RemoteRefresh`, sets it to `RemoteRefresh`. Useful when
 making the initial call to the server to indicate that we're currently fetching
-this resource
+this resource, or when updating or re-fetching a resource.
 
 ### Signature
 ```ts
@@ -83,108 +103,45 @@ assert.deepStrictEqual(
 );
 ```
 
-## refresh
+## withResource
 
-Like `fetch` but for the whole list.
+Add or update a single Resource.
+
+This method adds a single resource to the `RemoteCollection` representing the
+normal success-case for fetching the collection. If the resource is not
+currently in the set of resources, it is appened to the _end_ of the list at the
+key specified in the third argument. If you do not specify a key, the new
+resource will be appended to the list at `RemoteCollection.DEFAULT_KEY`. If the
+item _does_ exist already, that resource is replaced with the new value
+specified
 
 ### Signature
 ```ts
-refresh(): RemoteCollection<Resource>
+withResource(
+  id: string,
+  resource: Resource,
+  at?: string = RemoteCollection.DEFAULT_KEY
+): RemoteCollection<Resource>
 ```
 
-### Examples
+### Example
 ```ts
-const users: User[] = [{ id: 'a', name: 'Alice' }, { id: 'b', name: 'Bob' }];
 const collection = new RemoteCollection<User>();
 
 assert.deepStrictEqual(
-  collection.refresh().view(),
-  RemoteData.pending
+  collection.withResource(users[0].id, users.id).find(users[0].id),
+  RemoteData.success(users[0])
 );
-  
+
 assert.deepStrictEqual(
-  collection.withList('id', users).refresh().view(),
-  RemoteData.refresh(users)
+  collection.withResource(users[0].id, users.id).view(),
+  RemoteData.success([users[0]])
 );
-```
 
-## refreshAt
-
-Like `refresh` but for refreshing the collection at a given key. See
-`withListAt` for more details about `At`.
-
-### Signature
-```ts
-refreshAt(at: string): RemoteCollection<Resource>
-```
-
-## withList
-
-This method adds a list of resources to the `RemoteCollection` representing the
-normal success-case for fetching the collection.
-
-### Signature
-```ts
-withList(idProp: keyof Resource, list: Resource[]): RemoteCollection<Resource>
-```
-
-## withListAt
-
-Like `withList` but adds the resources to the underlying resource map, but
-stores the list of IDs at a specific key so you can retrieve this set of
-resources by that key. Useful for sub-resources (Post by User), pagination,
-filtered views, etc. Resources themselves are normalized by the `idProp`, so if
-two `At` views share some resources in common, they both point to the same
-underlying resource.
-
-### Signature
-```ts
-withListAt(at: string, idProp: keyof Resource, list: Resource[]): RemoteCollection<Resource>
-```
-
-## withResource
-
-This method adds a single resource to the `RemoteCollection` representing the
-normal success-case for fetching the collection. It appends the item to the end
-of the list of known IDs that is retrieved when you call `view`.
-
-### Signature
-```ts
-withResource(id: string, resource: Resource): RemoteCollection<Resource>
-```
-
-## withResourceAt
-
-Like `withResource` but adds the resource to the underlying resource map, but
-stores the new ID at a specific key so you can retrieve this set of resources by
-that key. Useful for sub-resources (Post by User), pagination, filtered views,
-etc. Resources themselves are normalized by the `idProp`, so if two `At` views
-share some resources in common, they both point to the same underlying resource.
-
-### Signature
-```ts
-withResourceAt(at: string, id: string, resource: Resource): RemoteCollection<Resource>
-```
-
-## withListFailure
-
-If requesting the list fails, calling this method will store a `RemoteFailure`
-with the passed `string`.
-
-### Signature
-```ts
-withListFailure(error: string): Collection<Resource>
-```
-
-## withListFailureAt
-
-Like `withListFailure` but adds the failure only to the stored list of resources
-at the specified key, but doesn't interfere with other keys or the resource map
-itself.
-
-### Signature
-```ts
-withListFailureAt(at: string, error: string): Collection<Resource>
+assert.deepStrictEqual(
+  collection.withResource(users[0].id, users.id, 'team1').view('team1'),
+  RemoteData.success([users[0]])
+);
 ```
 
 ## withResourceFailure
@@ -196,16 +153,6 @@ resource.
 ### Signature
 ```ts
 withResourceFailure(id: string, error: string): RemoteCollection<Resource>
-```
-
-## withResourceFailureAt
-
-The `At` version differs only in that requesting the view at the specified key
-will now see the newly errored resource.
-
-### Signature
-```ts
-withResourceFailureAt(at: string, id: string, error: string): RemoteCollection<Resource>
 ```
 
 ## find
@@ -239,11 +186,123 @@ assert.deepStrictEqual(
 );
 ```
 
+## remove
+
+Removes the resource indicated by the `id`.
+
+### Signature
+```ts
+remove(id: string): RemoteCollection<Resource>
+```
+
+### Examples
+
+```ts
+const users: User[] = [{ id: 'a', name: 'Alice' }, { id: 'b', name: 'Bob' }];
+const collection = new RemoteCollection<User>()
+  .withList('id', users);
+  
+assert.deepStrictEqual(
+  collection.view(),
+  RemoteData.success(users)
+);
+
+assert.deepStrictEqual(
+  collection.remove('a').view(),
+  RemoteData.success([users[1]])
+);
+```
+
+# Collection Methods
+
+## refresh
+
+Like `fetch` but for the whole list. The optional `at` arguments allows you to specify
+the view key to refresh.
+
+### Signature
+```ts
+refresh(at?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
+```
+
+### Examples
+```ts
+const users: User[] = [{ id: 'a', name: 'Alice' }, { id: 'b', name: 'Bob' }];
+const collection = new RemoteCollection<User>();
+
+assert.deepStrictEqual(
+  collection.refresh().view(),
+  RemoteData.pending
+);
+  
+assert.deepStrictEqual(
+  collection.withList('id', users).refresh().view(),
+  RemoteData.refresh(users)
+);
+  
+assert.deepStrictEqual(
+  collection.withList('id', users, 'team1').refresh('team1').view(),
+  RemoteData.refresh(users)
+);
+```
+
+## withList
+
+Set or replace the list of resources.
+
+This method adds a list of resources to the `RemoteCollection` representing the
+normal success-case for fetching the collection. The third optional argument
+specifies the key at which this view of the resources is stored at. If not
+provided, the list will be stored at the `RemoteCollection.DEFAULT_KEY` key.
+
+### Signature
+```ts
+withList(
+  idProp: keyof Resource,
+  list: Resource[],
+  at?: string = RemoteCollection.DEFAULT_KEY
+): RemoteCollection<Resource>
+```
+
+
+### Example
+```ts
+const collection = new RemoteCollection<User>();
+
+assert.deepStrictEqual(
+  collection.withList('id', users).view(),
+  RemoteData.success(users)
+);
+
+assert.deepStrictEqual(
+  collection.withList('id', users).view(),
+  collection.withList('id', users).view(RemoteCollection.DEFAULT_KEY)
+);
+
+assert.deepStrictEqual(
+  collection.withList('id', users, 'team1').view('team1'),
+  RemoteData.success(users)
+);
+```
+
+## withListFailure
+
+If requesting the list fails, calling this method will store a `RemoteFailure`
+with the passed `string` at the key specified by the second argument, or
+`RemoteCollection.DEFAULT_KEY` if not provided.
+
+### Signature
+```ts
+withListFailure(
+  error: string,
+  at?: string = RemoteCollection.DEFAULT_KEY
+): Collection<Resource>
+```
+
 ## view
 
-Without any arguments will return the list known resources. If `view` is given a
-list of `id` strings, it will attempt to lookup the resources by those IDs and
-return them in the same order. Missing IDs will be omitted entirely.
+Return the list of resources at a view key, or default to
+`RemoteCollection.DEFAULT_KEY` if none is provided.
 
 ### Signature
 ```ts
@@ -309,60 +368,88 @@ Here is a break down of what to expect:
     RemoteData.pending
   );
   ```
-
-## viewAt
-
-Like `view` but gets the list that was stored at the given key via `withListAt`,
-`withResourceAt`, `withFailureAt`.
-
-### Signature
-```ts
-public viewAt(at: string): RemoteData<string[], Resource[]>
-```
-
-## remove
-
-Removes the resource indicated by the `id`.
-
-### Signature
-```ts
-remove(id: string): RemoteCollection<Resource>
-```
-
-### Examples
+  
+Using a view key:
 
 ```ts
-const users: User[] = [{ id: 'a', name: 'Alice' }, { id: 'b', name: 'Bob' }];
 const collection = new RemoteCollection<User>()
-  .withList('id', users);
+  .withList('id', users, 'team1');
   
 assert.deepStrictEqual(
   collection.view(),
+  RemoteData.initial
+);
+
+assert.deepStrictEqual(
+  collection.view('team1'),
+  RemoteData.success(users);
+);
+```
+
+## concat
+
+If you need to append to the list, instead of replacing them, use this method.
+It is very similar to `withList`, and takes an optional view key as the third
+argument.
+
+### Signature
+```ts
+concatResources(
+  idProp: keyof Resource,
+  resources: Resource[],
+  at?: string = RemoteCollection.DEFAULT_KEY
+): RemoteCollection<Resource>
+```
+
+## map
+
+Apply a function to every resource at a view key.
+
+### Signature
+```ts
+map(
+  fn: (resource: Resource, index: string) => Resource,
+  at?: string = RemoteCollection.DEFAULT_KEY
+): RemoteCollection<Resource>
+```
+
+### Example
+```ts
+  const users: User[] = [
+    { id: 'a', name: 'Alice' },
+    { id: 'b', name: 'Bob' }
+  ];
+const collection = new RemoteCollection<User>().withList('id', users, 'team1');
+
+assert.deepStrictEqual(
+  collection.map(u => ({ ...u, name: u.name.toUpperCase() }), 'team1'),
+  RemoteData.success([
+    { id: 'a', name: 'ALICE' },
+    { id: 'b', name: 'BOB' }
+  ])
+);
+```
+
+## reset
+
+Removes the view at the given key, or at the `RemoteCollection.DEFAULT_KEY`.
+
+### Signature
+```ts
+reset(at?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
+```
+
+### Example
+```ts
+const collection = new RemoteCollection<User>().withList('id', users, 'team1');
+
+assert.deepStrictEqual(
+  collection.view('team1'),
   RemoteData.success(users)
 );
 
 assert.deepStrictEqual(
-  collection.remove('a').view(),
-  RemoteData.success([users[1]])
+  collection.reset('team1').view('team1'),
+  RemoteData.initial
 );
-```
-
-## removeAt
-
-Like `remove` but _only_ removes the resource from the list at the indicated
-key. If the resource is also available at other keys, it will still be there.
-
-### Signature
-```ts
-removeAt(at: string, id: string): RemoteCollection<Resource>
-```
-
-## concatResources
-
-If you need to append to the list, instead of replacing them, use this method.
-It is very similar to `withList`.
-
-### Signature
-```ts
-concatResources(idProp: keyof Resource, resources: Resource[]): RemoteCollection<Resource>
 ```

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ individual resources:
 
 | Remote State | Collection | Resource |
 |---|---|---|
-|`RemoteInitial`|`reset`|`remove`|
-|`RemotePending`|`refresh`|`fetch`|
-|`RemoteFailure`|`withListFailure`|`withResourceFailure`|
-|`RemoteRefresh`|`refresh`|`fetch`|
-|`RemoteSuccess`|`withList`|`withResource`|
+|`RemoteInitial`|[`reset`](#reset) |[`remove`](#remove)|
+|`RemotePending`|[`refresh`](#refresh) |[`fetch`](#fetch)|
+|`RemoteFailure`|[`withListFailure`](#withlistfailure)|[`withResourceFailure`](#withresourcefailure) |
+|`RemoteRefresh`|[`refresh`](#refresh)|[`fetch`](#fetch)|
+|`RemoteSuccess`|[`withList`](#withlist)|[`withResource`](#withresource)|
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ specified
 ```ts
 withResource(
   resource: Resource,
-  at?: string = RemoteCollection.DEFAULT_KEY
+  viewKey?: string = RemoteCollection.DEFAULT_KEY
 ): RemoteCollection<Resource>
 ```
 
@@ -221,7 +221,7 @@ the view key to refresh.
 
 ### Signature
 ```ts
-refresh(at?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
+refresh(viewKey?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
 ```
 
 ### Examples
@@ -257,7 +257,7 @@ second argument, or `RemoteCollection.DEFAULT_KEY` if not provided.
 ```ts
 withList(
   list: Resource[],
-  at?: string = RemoteCollection.DEFAULT_KEY
+  viewKey?: string = RemoteCollection.DEFAULT_KEY
 ): RemoteCollection<Resource>
 ```
 
@@ -292,7 +292,7 @@ with the passed `string` at the view key specified by the second argument, or
 ```ts
 withListFailure(
   error: string,
-  at?: string = RemoteCollection.DEFAULT_KEY
+  viewKey?: string = RemoteCollection.DEFAULT_KEY
 ): Collection<Resource>
 ```
 
@@ -303,7 +303,7 @@ Return the list of resources at a view key, or default to
 
 ### Signature
 ```ts
-public view(at?: string = RemoteCollection.DEFAULT_KEY): RemoteData<string[], Resource[]>
+public view(viewKey?: string = RemoteCollection.DEFAULT_KEY): RemoteData<string[], Resource[]>
 ```
 
 ### Examples
@@ -393,7 +393,7 @@ argument.
 ```ts
 concat(
   resources: Resource[],
-  at?: string = RemoteCollection.DEFAULT_KEY
+  viewKey?: string = RemoteCollection.DEFAULT_KEY
 ): RemoteCollection<Resource>
 ```
 
@@ -405,7 +405,7 @@ Apply a function to every resource at a view key.
 ```ts
 map(
   fn: (resource: Resource, index: string) => Resource,
-  at?: string = RemoteCollection.DEFAULT_KEY
+  viewKey?: string = RemoteCollection.DEFAULT_KEY
 ): RemoteCollection<Resource>
 ```
 
@@ -428,11 +428,12 @@ assert.deepStrictEqual(
 
 ## reset
 
-Removes the view at the given key, or at the `RemoteCollection.DEFAULT_KEY`.
+Removes the view at the given view key, or at the
+`RemoteCollection.DEFAULT_KEY`.
 
 ### Signature
 ```ts
-reset(at?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
+reset(viewKey?: string = RemoteCollection.DEFAULT_KEY): RemoteCollection<Resource>
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ assert.deepStrictEqual(
 Set or replace the list of resources.
 
 This method adds a list of resources to the `RemoteCollection` representing the
-normal success-case for fetching the collection.
+normal success-case for fetching the collection at the view key specified by the
+second argument, or `RemoteCollection.DEFAULT_KEY` if not provided.
 
 ### Signature
 ```ts
@@ -284,7 +285,7 @@ assert.deepStrictEqual(
 ## withListFailure
 
 If requesting the list fails, calling this method will store a `RemoteFailure`
-with the passed `string` at the key specified by the second argument, or
+with the passed `string` at the view key specified by the second argument, or
 `RemoteCollection.DEFAULT_KEY` if not provided.
 
 ### Signature

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ resource are possiblity divergent, so `RemoteCollection` stores those states
 separately. You may have a failure state in one of your resources, but are
 refetching the whole list, and `RemoteCollection` tracks both states.
 
+## Transitioning the RemoteData state
+
+A helpful cheatsheet for how to transition to the different
+[`RemoteData`](https://github.com/ca-la/remote-data) states for collections vs
+individual resources:
+
+| Remote State | Collection | Resource |
+|---|---|---|
+|`RemoteInitial`|`reset`|`remove`|
+|`RemotePending`|`refresh`|`fetch`|
+|`RemoteFailure`|`withListFailure`|`withResourceFailure`|
+|`RemoteRefresh`|`refresh`|`fetch`|
+|`RemoteSuccess`|`withList`|`withResource`|
+
 # Usage
 
 ## RemoteCollection (Constructor)


### PR DESCRIPTION
Going to start with a README update and see if this API and the explanations make sense!

The rough sketch of the API is this:

- Operations on views
  - `withList`/`withListFailure`, Replace list
  - `view`, Show a view of the data
  - `concat`, Add to list
  - `map`, Update resources in list
  - `refresh`, Set list's remote state to pending/refresh
  - `reset`, Set the list back to initial
- Operations on resources
  - `withResource`/`withResourceFailure`, Replace resource
  - `remove`, Remove/reset resource
  - `fetch`, Set resource's remote state to pending/refresh
  - `find`, Look up resource by ID

Another big change here is moving the `idProp` into the constructor. I've had a hard time remembering that the `list` stuff takes the property name, and the `resource` stuff takes the actual `id`, and since it doesn't actually change, it seems like an obvious win to move it to the constructor.