### PR TITLE
Add a map method from Resource to Partial<Resource>

### DIFF
--- a/src/__tests__/map.ts
+++ b/src/__tests__/map.ts
@@ -1,0 +1,35 @@
+import test from 'ava';
+import * as RD from '@cala/remote-data';
+import Collection from '../index';
+import { Item, items } from './fixtures';
+
+interface FooCount {
+  id: string;
+  count: number;
+}
+
+const countFoo = (a: Item): FooCount => ({
+  id: a.id,
+  count: a.foo.length
+});
+
+test('with no items loaded, #map', t => {
+  const col = new Collection<Item>().map(countFoo);
+  t.deepEqual(col.knownIds, RD.initial);
+  t.deepEqual(col.entities, {});
+});
+
+test('with items loaded, #map on an existing ID', t => {
+  const col = new Collection<Item>().withList('id', items).map(countFoo);
+  t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']));
+  t.deepEqual(col.entities, {
+    a: RD.success<string[], FooCount>({ id: 'a', count: 3 }),
+    b: RD.success<string[], FooCount>({ id: 'b', count: 3 })
+  });
+});
+
+test('with item loading failure, #map', t => {
+  const col = new Collection<Item>().withListFailure('Failed').map(countFoo);
+  t.deepEqual(col.knownIds, RD.failure<string[], string[]>(['Failed']));
+  t.deepEqual(col.entities, {});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,18 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
+  public map<B extends Partial<Resource>>(mapFunction: (resource: Resource) => B): Collection<B> {
+    const col = new Collection<B>();
+    col.knownIds = this.knownIds;
+    col.idMap = this.idMap;
+    col.entities = mapValues<RemoteById<Resource>, Remote<B>>(
+      this.entities,
+      (entity: Remote<Resource> | undefined) => (entity ? entity.map(mapFunction) : RD.initial)
+    );
+
+    return col;
+  }
+
   public mapResource(
     id: string,
     mapFunction: (resource: Resource) => Resource


### PR DESCRIPTION
The typical use case here is when reviving stringified JSON, things like `Date`s don't get parsed back into their original data type, so this would allow mapping over a `RemoteCollection<Serialized<A>>` and getting a `RemoteCollection<A>`.

Not thrilled that the best we can do with "`B` still has the same `idProp`" is `Partial<A>`, but since we don't know `idProp` at compile time, this is the best we can do. 😬 We can definitely run risk of `id` getting removed, or the value at `id` getting changed and being out-of-sync with the `entities` map, but that shouldn't affect _our_ usecase, so 🤷‍♂ 