### PR TITLE
Allow arbitrary transformations of `Resource` with `map`

### DIFF
--- a/src/__tests__/map.ts
+++ b/src/__tests__/map.ts
@@ -5,12 +5,12 @@ import { Item, items } from './fixtures';
 
 interface FooCount {
   id: string;
-  count: number;
+  foo: number;
 }
 
 const countFoo = (a: Item): FooCount => ({
   id: a.id,
-  count: a.foo.length
+  foo: a.foo.length
 });
 
 test('with no items loaded, #map', t => {
@@ -23,8 +23,8 @@ test('with items loaded, #map on an existing ID', t => {
   const col = new Collection<Item>().withList('id', items).map(countFoo);
   t.deepEqual(col.knownIds, RD.success<string[], string[]>(['a', 'b']));
   t.deepEqual(col.entities, {
-    a: RD.success<string[], FooCount>({ id: 'a', count: 3 }),
-    b: RD.success<string[], FooCount>({ id: 'b', count: 3 })
+    a: RD.success<string[], FooCount>({ id: 'a', foo: 3 }),
+    b: RD.success<string[], FooCount>({ id: 'b', foo: 3 })
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export default class Collection<Resource extends { [key: string]: any }> {
     return col;
   }
 
-  public map<B extends Partial<Resource>>(mapFunction: (resource: Resource) => B): Collection<B> {
+  public map<B>(mapFunction: (resource: Resource) => B): Collection<B> {
     const col = new Collection<B>();
     col.knownIds = this.knownIds;
     col.idMap = this.idMap;


### PR DESCRIPTION
Should've tested out this use-case, but we're going from types that are like:
```ts
interface SerializedFoo {
  maybeDate: string | null;
}
```

to

```ts
interface Foo {
  maybeDate: Date | null;
}
```

And `Partial` doesn't allow you to "override" the given input type, so since the `Partial` constraint wasn't even really enforcing the more useful property of not dropping the `id`, let's just loosen it up altogether!