### PR TITLE
Fix concat logic not handling the cases with no data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,13 @@ export default class RemoteCollection<Resource extends { [key: string]: any }> {
       (key, acc, remoteList) => {
         const existingList = lookup(key, acc);
         const concatenated = existingList.fold(remoteList, existing =>
-          existing.chain(list => remoteList.map(l => list.concat(l)))
+          existing.fold(
+            remoteList,
+            remoteList,
+            () => remoteList,
+            list => remoteList.map(l => list.concat(l)),
+            list => remoteList.map(l => list.concat(l))
+          )
         );
 
         return insert(key, concatenated, acc);
@@ -257,7 +263,10 @@ function isRemoteCollectionJSON<A>(
   );
 }
 
-export function fromJSON<A>(_: string, value: unknown): RemoteCollection<A> | unknown {
+export function fromJSON<A>(
+  _: string,
+  value: unknown
+): RemoteCollection<A> | unknown {
   if (isRemoteCollectionJSON<A>(value)) {
     const remoteCollection: RemoteCollection<A> = new RemoteCollection<A>(
       value.idProp


### PR DESCRIPTION
Given `a.concat(b)`, by using `chain`, it was only handling the `refresh` and `success` cases for `a`, and always returning `a` in other cases. This change ends up "preferring" b by mapping the `initial`, `pending`, `failure` states to return `b`.

The basic use case for `concat` is to (kinda) upsert new data to existing data, so that when transitioning from `pending` -> `success`, it properly sets the value to `success`.